### PR TITLE
refactor: use window.phantom

### DIFF
--- a/src/utils/getProvider.ts
+++ b/src/utils/getProvider.ts
@@ -5,11 +5,11 @@ import { PhantomProvider } from '../types';
  * @returns {PhantomProvider | undefined} a Phantom provider if one exists in the window
  */
 const getProvider = (): PhantomProvider | undefined => {
-  if ('solana' in window) {
+  if ('phantom' in window) {
     const anyWindow: any = window;
-    const provider = anyWindow.solana;
+    const provider = anyWindow.phantom?.solana;
 
-    if (provider.isPhantom) {
+    if (provider?.isPhantom) {
       return provider;
     }
   }


### PR DESCRIPTION
Given the upcoming changes to the Solana Wallet Adapter, we will now promote window.phantom over window.solana