### PR TITLE
add skipPreflight in sendoptions

### DIFF
--- a/src/utils/signAndSendTransaction.ts
+++ b/src/utils/signAndSendTransaction.ts
@@ -13,7 +13,7 @@ const signAndSendTransaction = async (
   transaction: Transaction | VersionedTransaction
 ): Promise<string> => {
   try {
-    const { signature } = await provider.signAndSendTransaction(transaction);
+    const { signature } = await provider.signAndSendTransaction(transaction, {skipPreflight: false});
     return signature;
   } catch (error) {
     console.warn(error);


### PR DESCRIPTION
This change is related to wallet-standard to set skipPreflight in sendOptions: https://linear.app/phantom-labs/issue/ECO-1619/fix-solana-sandbox-invalid-parameters-bug

## How I know it works
Can test it out here on mobile: https://otdsz1.csb.app/

https://user-images.githubusercontent.com/23377962/221092288-b5bfc50a-0da7-47ef-a873-f4cb40ac6e94.mp4

